### PR TITLE
Fix fetching ruby include dir

### DIFF
--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -41,7 +41,7 @@ generate_ctags_for() {
     return 1
   fi
 
-  local ruby_include_dir="$(ls -d $1/include/ruby-*)"
+  local ruby_include_dir="$(RBENV_VERSION=$version ruby -rrbconfig -e 'print RbConfig::CONFIG["rubyhdrdir"] || RbConfig::CONFIG["topdir"]')"
   if [ -w "$ruby_include_dir" ]; then
     generate_ctags_in "$ruby_include_dir" "C,C++" "${RUBY_BUILD_BUILD_PATH:-$ruby_include_dir}"
   else


### PR DESCRIPTION
Hi,
this PR is a fix for a bug introduced in #5.

Let me explain what went wrong there for rubies 1.8.7:

- so ruby 1.8.7 does not have `include/` dir (the dir with ruby C header files is on some other path)
- the bug was in this line `local ruby_include_dir="$(ls -d $1/include/ruby-*)"`
- since the script has `shopt -s nullglob` option set, `$1/include/ruby-*` expands to empty string. Then `ls -d` command evaluates to `.` (dot). And the rest are the symptoms.

The first simple fix for the bug I had gets the `include/` dir expansion correctly.

    local ruby_include_dir="$(echo $1/include/ruby-*/)"

However I propose a different fix in this PR that should work:

- without guesses about the directory structure
- correctly on MRI 1.8.7 (and above of course)
- even if compiled ruby directory structure changes in the future
- even on non MRI rubies (tested with jruby and rubinius)