### PR TITLE
Force to use the selected Ruby version's binary.

### DIFF
--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -41,7 +41,7 @@ generate_ctags_for() {
     return 1
   fi
 
-  local ruby_include_dir="$(RBENV_VERSION=$version ruby -rrbconfig -e 'print RbConfig::CONFIG["rubyhdrdir"] || RbConfig::CONFIG["topdir"]')"
+  local ruby_include_dir="$(RBENV_VERSION=$version rbenv exec ruby -rrbconfig -e 'print RbConfig::CONFIG["rubyhdrdir"] || RbConfig::CONFIG["topdir"]')"
   if [ -w "$ruby_include_dir" ]; then
     generate_ctags_in "$ruby_include_dir" "C,C++" "${RUBY_BUILD_BUILD_PATH:-$ruby_include_dir}"
   else


### PR DESCRIPTION
The `ruby` shim doesn't exist before the first time you install ruby by rbenv.  Running `ruby` means running `/usr/bin/ruby` which is wrong.  Installing the first Ruby version will always fail.