### PR TITLE
Avoid rbenv wrapper when invoking rbenv-exec

### DIFF
--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -41,7 +41,7 @@ generate_ctags_for() {
     return 1
   fi
 
-  local ruby_include_dir="$(RBENV_VERSION=$version rbenv exec ruby -rrbconfig -e 'print RbConfig::CONFIG["rubyhdrdir"] || RbConfig::CONFIG["topdir"]')"
+  local ruby_include_dir="$(RBENV_VERSION=$version rbenv-exec ruby -rrbconfig -e 'print RbConfig::CONFIG["rubyhdrdir"] || RbConfig::CONFIG["topdir"]')"
   if [ -w "$ruby_include_dir" ]; then
     generate_ctags_in "$ruby_include_dir" "C,C++" "${RUBY_BUILD_BUILD_PATH:-$ruby_include_dir}"
   else


### PR DESCRIPTION
When in the context of a plugin, the main rbenv wrapper has already been
executed. It's preferable to directly execute the rbenv subcommands via
`rbenv-X` instead of `rbenv X` as the wrapper doesn't need invoked
again.