### PR TITLE
Leverage rbenv-prefix to derive ruby location

### DIFF
--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -52,11 +52,11 @@ generate_ctags_for() {
 
 if [ $# = 0 -o --all = "$1" ]; then
   for version in $(rbenv-versions --bare); do
-    [ -L "$RBENV_ROOT/versions/$version" ] || \
-      generate_ctags_for "$RBENV_ROOT/versions/$version"
+    [ -L "$(rbenv-prefix "$version")" ] || \
+      generate_ctags_for "$(rbenv-prefix "$version")"
   done
 else
   for version in "$@"; do
-    generate_ctags_for "$RBENV_ROOT/versions/$version"
+    generate_ctags_for "$(rbenv-prefix "$version")"
   done
 fi


### PR DESCRIPTION
We "know" that an rbenv ruby's location is
$RBENV_ROOT/versions/$version, but it's better to rely on rbenv managing
that bit of information.

rbenv-prefix returns the path to a ruby, if given a version (or the
currently-active ruby if not)