### PR TITLE
Attempt to use ripper-tags, if installed

### DIFF
--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -17,7 +17,11 @@ generate_ctags_in() {
   local languages="${2:-Ruby}"
   local source_code_dir="${3:-$tags_file_dir}"
   echo "Running ctags on $source_code_dir"
-  (cd "$tags_file_dir"; ctags --languages="$languages" -R --tag-relative=yes "$source_code_dir")
+  if [[ "$languages" == "Ruby" ]] && command -v ripper-tags 2>&1 >/dev/null; then
+    (cd "$tags_file_dir"; ripper-tags --recursive --tag-relative=yes "$source_code_dir")
+  else
+    (cd "$tags_file_dir"; ctags --languages="$languages" --recurse --tag-relative=yes "$source_code_dir")
+  fi
 }
 
 generate_ctags_for() {

--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -17,7 +17,7 @@ generate_ctags_in() {
   local languages="${2:-Ruby}"
   local source_code_dir="${3:-$tags_file_dir}"
   echo "Running ctags on $source_code_dir"
-  if [[ "$languages" == "Ruby" ]] && command -v ripper-tags 2>&1 >/dev/null; then
+  if [[ "$languages" == "Ruby" ]] && rbenv-which ripper-tags 2>&1 >/dev/null; then
     (cd "$tags_file_dir"; ripper-tags --recursive --tag-relative=yes "$source_code_dir")
   else
     (cd "$tags_file_dir"; ctags --languages="$languages" --recurse --tag-relative=yes "$source_code_dir")


### PR DESCRIPTION
[ripper-tags](https://github.com/tmm1/ripper-tags) providers much more comprehensive tags than [exuberant] ctags. For example, trying to find a tag for `Gem::Specification` in the vendored rubygems doesn't find the primary definition:

```
  # pri kind tag               file
> 1 F   c    Specification     /usr/local/rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/rubygems_ext.rb
               class:Gem
               class Specification
  2 F   c    Specification     /usr/local/rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/rubygems_ext.rb
               class:Gem
               class Specification
```

After using ripper-tags, the primary file is included (even if still not the default):
```
  # pri kind tag               file
> 1 F   c    Specification     /usr/local/rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/rubygems_ext.rb
               class:Gem
               class Specification
  2 F   c    Specification     /usr/local/rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/resolver/specification.rb
               class:Gem.Resolver
               class Gem::Resolver::Specification
  3 F   c    Specification     /usr/local/rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb
               class:Gem inherits:Gem.BasicSpecification
               class Gem::Specification < Gem::BasicSpecification
  4 F   c    Specification     /usr/local/rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/rubygems_ext.rb
               class:Gem
               class Specification
  5 F   c    Specification     /usr/local/rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/resolver/specification.rb
               class:Gem.Resolver
               class Gem::Resolver::Specification
  6 F   c    Specification     /usr/local/rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/specification.rb
               class:Gem inherits:Gem.BasicSpecification
               class Gem::Specification < Gem::BasicSpecification
```

Personally I don't mind that this requires running `rbenv ctags` again after a `gem install ripper-tags` — the extra step is worth it for me. But I'll probably combine this with [rbenv-default-gems](https://github.com/rbenv/rbenv-default-gems) somehow, if I can figure out ordering.

Fixes #4.