### PR TITLE
Add option to use ripper-tags, if installed

### DIFF
--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -2,9 +2,9 @@
 #
 # Summary: Generate ctags for a given version's standard library
 #
-# Usage: rbenv ctags
-#        rbenv ctags <version> [<version> ...] [--ripper]
-#        rbenv ctags --all [--ripper]
+# Usage: rbenv ctags [--ripper]
+#        rbenv ctags [--ripper] <version> [<version> ...]
+#        rbenv ctags [--ripper] --all
 
 shopt -s nullglob
 

--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -36,7 +36,7 @@ generate_ctags_in() {
   local languages="${2:-Ruby}"
   local source_code_dir="${3:-$tags_file_dir}"
   echo "Running ctags on $source_code_dir"
-  if [[ "$languages" == "Ruby" ]] && command -v ripper-tags 2>&1 >/dev/null; then
+  if [[ "$languages" == "Ruby" ]] && rbenv-which ripper-tags 2>&1 >/dev/null; then
     (cd "$tags_file_dir"; ripper-tags --recursive --tag-relative=yes "$source_code_dir")
   else
     (cd "$tags_file_dir"; ctags --languages="$languages" --recurse --tag-relative=yes "$source_code_dir")

--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -36,7 +36,11 @@ generate_ctags_in() {
   local languages="${2:-Ruby}"
   local source_code_dir="${3:-$tags_file_dir}"
   echo "Running ctags on $source_code_dir"
-  (cd "$tags_file_dir"; ctags --languages="$languages" -R --tag-relative=yes "$source_code_dir")
+  if [[ "$languages" == "Ruby" ]] && command -v ripper-tags 2>&1 >/dev/null; then
+    (cd "$tags_file_dir"; ripper-tags --recursive --tag-relative=yes "$source_code_dir")
+  else
+    (cd "$tags_file_dir"; ctags --languages="$languages" --recurse --tag-relative=yes "$source_code_dir")
+  fi
 }
 
 generate_ctags_for() {

--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -5,6 +5,7 @@
 # Usage: rbenv ctags
 #        rbenv ctags <version> [<version> ...]
 #        rbenv ctags --all
+#        rbenv ctags --ripper
 
 shopt -s nullglob
 
@@ -21,6 +22,9 @@ for arg; do
     -a|--all)
       all=1
       ;;
+    --ripper)
+      ripper=1
+      ;;
     -*)
       rbenv-help --usage ctags >&2
       exit 1
@@ -35,10 +39,11 @@ generate_ctags_in() {
   local tags_file_dir="$1"
   local languages="${2:-Ruby}"
   local source_code_dir="${3:-$tags_file_dir}"
-  echo "Running ctags on $source_code_dir"
-  if [[ "$languages" == "Ruby" ]] && rbenv-which ripper-tags 2>&1 >/dev/null; then
+  if [[ "$languages" == "Ruby" ]] && [ -n "$ripper" ] && rbenv-which ripper-tags 2>&1 >/dev/null; then
+    echo "Running ripper-tags on $source_code_dir"
     (cd "$tags_file_dir"; ripper-tags --recursive --tag-relative=yes "$source_code_dir")
   else
+    echo "Running ctags on $source_code_dir"
     (cd "$tags_file_dir"; ctags --languages="$languages" --recurse --tag-relative=yes "$source_code_dir")
   fi
 }
@@ -74,6 +79,10 @@ generate_ctags_for() {
     return 1
   fi
 }
+
+if [ -n "$ripper" ] && ! rbenv-which ripper-tags 2>&1 >/dev/null; then
+  exit "1"
+fi
 
 if [ -n "$all" ]; then
   for version in $(rbenv-versions --bare); do

--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -3,9 +3,8 @@
 # Summary: Generate ctags for a given version's standard library
 #
 # Usage: rbenv ctags
-#        rbenv ctags <version> [<version> ...]
-#        rbenv ctags --all
-#        rbenv ctags --ripper
+#        rbenv ctags <version> [<version> ...] [--ripper]
+#        rbenv ctags --all [--ripper]
 
 shopt -s nullglob
 
@@ -81,7 +80,7 @@ generate_ctags_for() {
 }
 
 if [ -n "$ripper" ] && ! rbenv-which ripper-tags 2>&1 >/dev/null; then
-  exit "1"
+  exit 1
 fi
 
 if [ -n "$all" ]; then


### PR DESCRIPTION
This pull request picks up on https://github.com/tpope/rbenv-ctags/pull/14 by implementing the requested change of adding a `--ripper` flag.