### PR TITLE
Update installation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ gems][gem-ctags].  All I'm missing is tags for Ruby stdlib.  Until now.
 ## Installation
 
     mkdir -p ~/.rbenv/plugins
-    git clone git://github.com/tpope/rbenv-ctags.git \
+    git clone https://github.com/tpope/rbenv-ctags.git \
       ~/.rbenv/plugins/rbenv-ctags
     rbenv ctags
 


### PR DESCRIPTION

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/41264693/166453779-2ee5a541-1382-4a2e-ae8e-7b85d7410201.png">

Due to [Improving Git protocol security on GitHub](https://github.blog/2021-09-01-improving-git-protocol-security-github/), the unauthenticated git protocol is no longer supported