### PR TITLE
Fix language option case

### DIFF
--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -33,7 +33,7 @@ done
 
 generate_ctags_in() {
   local tags_file_dir="$1"
-  local languages="${2:-ruby}"
+  local language="${2:-ruby}"
   local source_code_dir="${3:-$tags_file_dir}"
   echo "Running ctags on $source_code_dir"
   (cd "$tags_file_dir"; ctags --languages="$languages" -R --tag-relative=yes "$source_code_dir")

--- a/bin/rbenv-ctags
+++ b/bin/rbenv-ctags
@@ -33,7 +33,7 @@ done
 
 generate_ctags_in() {
   local tags_file_dir="$1"
-  local languages="${2:-Ruby}"
+  local languages="${2:-ruby}"
   local source_code_dir="${3:-$tags_file_dir}"
   echo "Running ctags on $source_code_dir"
   (cd "$tags_file_dir"; ctags --languages="$languages" -R --tag-relative=yes "$source_code_dir")


### PR DESCRIPTION
I get the following error on macOS.

```
Running ctags on /Users/matthew/.rbenv/versions/3.2.2/lib/ruby/3.2.0
ctags: unrecognized option '--languages=Ruby'
	Try 'ctags --help' for a complete list of options.
```

I suspect it is due to the uppercase option provided by this library to the `ctags` command.

`ctags --help` leads me to believe that the `--languages` options should be lowercase `ruby`.

```
These are the currently supported languages, along with the
default file names and dot suffixes:
  ada        .ads .adb .ada
  asm        .a .asm .def .inc .ins .s .sa .S .src
  c          .c .h
  c++        .C .c++ .cc .cpp .cxx .H .h++ .hh .hpp .hxx .M .pdb
  c*         .cs .hs
  cobol      .COB .cob
  erlang     .erl .hrl
  forth      .fth .tok
  fortran    .F .f .f90 .for
  go         .go
  html       .htm .html .shtml
  java       .java
  lisp       .cl .clisp .el .l .lisp .LSP .lsp .ml
  lua        .lua .LUA
  makefile   Makefile makefile GNUMakefile Makefile.in Makefile.am
  objc       .lm .m
  mercury    .m
  pascal     .p .pas
  perl       .pl .pm
  php        .php .php3 .php4
  postscript .ps .psw
  proc       .pc
  prolog     .prolog
  python     .py
  ruby       Rakefile Thorfile .rb .ru .rbw
  rust       .rs
  scheme     .oak .rkt .sch .scheme .SCM .scm .SM .sm .ss .t
  tex        .bib .clo .cls .ltx .sty .TeX .tex
  texinfo    .texi .texinfo .txi
  yacc       .y .y++ .ym .yxx .yy
  auto
  none
```